### PR TITLE
Prevent double charging on idempotent register calls

### DIFF
--- a/contracts/registries/IPAssetRegistry.sol
+++ b/contracts/registries/IPAssetRegistry.sol
@@ -101,6 +101,14 @@ contract IPAssetRegistry is
         uint256 tokenId,
         address registerFeePayer
     ) internal override returns (address id) {
+        id = _registerIpAccount(chainid, tokenContract, tokenId);
+        IIPAccount ipAccount = IIPAccount(payable(id));
+
+        // return if the IP was already registered
+        if (bytes(ipAccount.getString("NAME")).length != 0) {
+            return id;
+        }
+
         IPAssetRegistryStorage storage $ = _getIPAssetRegistryStorage();
 
         // Pay registration fee
@@ -110,14 +118,6 @@ contract IPAssetRegistry is
             address treasury = $.treasury;
             IERC20(feeToken).safeTransferFrom(registerFeePayer, treasury, uint256(feeAmount));
             emit IPRegistrationFeePaid(registerFeePayer, treasury, feeToken, feeAmount);
-        }
-
-        id = _registerIpAccount(chainid, tokenContract, tokenId);
-        IIPAccount ipAccount = IIPAccount(payable(id));
-
-        // return if the IP was already registered
-        if (bytes(ipAccount.getString("NAME")).length != 0) {
-            return id;
         }
 
         (string memory name, string memory uri) = _getNameAndUri(chainid, tokenContract, tokenId);


### PR DESCRIPTION
## Description

I think `register` is meant to be idempotent. But we are charging the pay registration fee again on each call.

This should be called after the check:
```
        // Pay registration fee
        uint96 feeAmount = $.feeAmount;
        if (feeAmount > 0) {
            address feeToken = $.feeToken;
            address treasury = $.treasury;
            IERC20(feeToken).safeTransferFrom(registerFeePayer, treasury, uint256(feeAmount));
            emit IPRegistrationFeePaid(registerFeePayer, treasury, feeToken, feeAmount);
        }
```

